### PR TITLE
Fixed a bug about multi label sequence classification 

### DIFF
--- a/easynlp/appzoo/sequence_classification/data.py
+++ b/easynlp/appzoo/sequence_classification/data.py
@@ -85,7 +85,6 @@ class ClassificationDataset(BaseDataset):
             self.tokenidVec, self.positionidVec = self.kangaroo_get_contrastive_samples(CL_samples_file)
             self.conceptEmbVec = self.kangaroo_get_concept_emb(concept_emb_file)
 
-        user_defined_parameters = kwargs.get('user_defined_parameters', {})
         self.multi_label = user_defined_parameters.get('app_parameters', {}).get('multi_label', False)
 
         if label_enumerate_values is None:

--- a/easynlp/appzoo/sequence_classification/data.py
+++ b/easynlp/appzoo/sequence_classification/data.py
@@ -38,7 +38,6 @@ class ClassificationDataset(BaseDataset):
         label_name: label column name
         second_sequence: set as None
         label_enumerate_values: a list of label values
-        multi_label: set as True if perform multi-label classification, otherwise False
     """
     def __init__(self,
                  pretrained_model_name_or_path,


### PR DESCRIPTION
1. Deleted the multi_label parameter description.
2. The user_defined_parameters shouldn't get from the kwargs. This will cause the bug that the user_defined_parameters become None and can't get the multi_label parameter in multi-label sequence classification model.